### PR TITLE
fix: handle missing pnpapi

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -281,22 +281,22 @@ namespace ts {
 
     /**
      * Returns the path to every node_modules/@types directory from some ancestor directory.
-     * Returns undefined if there are none.
      */
-    function getDefaultTypeRoots(currentDirectory: string, host: { directoryExists?: (directoryName: string) => boolean }): string[] | undefined {
+    function getNodeModulesTypeRoots(currentDirectory: string, host: { directoryExists?: (directoryName: string) => boolean }) {
         if (!host.directoryExists) {
             return [combinePaths(currentDirectory, nodeModulesAtTypes)];
             // And if it doesn't exist, tough.
         }
 
-        let typeRoots: string[] | undefined;
+        const typeRoots: string[] = [];
         forEachAncestorDirectory(normalizePath(currentDirectory), directory => {
             const atTypes = combinePaths(directory, nodeModulesAtTypes);
             if (host.directoryExists!(atTypes)) {
-                (typeRoots || (typeRoots = [])).push(atTypes);
+                typeRoots.push(atTypes);
             }
             return undefined;
         });
+
         return typeRoots;
     }
     const nodeModulesAtTypes = combinePaths("node_modules", "@types");
@@ -304,6 +304,50 @@ namespace ts {
     function arePathsEqual(path1: string, path2: string, host: ModuleResolutionHost): boolean {
         const useCaseSensitiveFileNames = typeof host.useCaseSensitiveFileNames === "function" ? host.useCaseSensitiveFileNames() : host.useCaseSensitiveFileNames;
         return comparePaths(path1, path2, !useCaseSensitiveFileNames) === Comparison.EqualTo;
+    }
+
+    /**
+     * @internal
+     */
+    export function getPnpTypeRoots(currentDirectory: string) {
+        const pnpapi = getPnpApi(currentDirectory);
+        if (!pnpapi) {
+            return [];
+        }
+
+        // Some TS consumers pass relative paths that aren't normalized
+        currentDirectory = sys.resolvePath(currentDirectory);
+
+        const currentPackage = pnpapi.findPackageLocator(`${currentDirectory}/`);
+        if (!currentPackage) {
+            return [];
+        }
+
+        const {packageDependencies} = pnpapi.getPackageInformation(currentPackage);
+
+        const typeRoots: string[] = [];
+        for (const [name, referencish] of Array.from<any>(packageDependencies.entries())) {
+            // eslint-disable-next-line no-null/no-null
+            if (name.startsWith(typesPackagePrefix) && referencish !== null) {
+                const dependencyLocator = pnpapi.getLocator(name, referencish);
+                const {packageLocation} = pnpapi.getPackageInformation(dependencyLocator);
+
+                typeRoots.push(getDirectoryPath(packageLocation));
+            }
+        }
+
+        return typeRoots;
+    }
+
+    const typesPackagePrefix = "@types/";
+
+    function getDefaultTypeRoots(currentDirectory: string, host: { directoryExists?: (directoryName: string) => boolean }): string[] | undefined {
+        const nmTypes = getNodeModulesTypeRoots(currentDirectory, host);
+        const pnpTypes = getPnpTypeRoots(currentDirectory);
+
+        if (nmTypes.length > 0 || pnpTypes.length > 0) {
+            return [...nmTypes, ...pnpTypes];
+        }
     }
 
     /**
@@ -454,7 +498,10 @@ namespace ts {
                 }
                 let result: Resolved | undefined;
                 if (!isExternalModuleNameRelative(typeReferenceDirectiveName)) {
-                    const searchResult = loadModuleFromNearestNodeModulesDirectory(Extensions.DtsOnly, typeReferenceDirectiveName, initialLocationForSecondaryLookup, moduleResolutionState, /*cache*/ undefined, /*redirectedReference*/ undefined);
+                    const searchResult = getPnpApi(initialLocationForSecondaryLookup)
+                        ? tryLoadModuleUsingPnpResolution(Extensions.DtsOnly, typeReferenceDirectiveName, initialLocationForSecondaryLookup, moduleResolutionState, /*cache*/ undefined, /*redirectedReference*/ undefined)
+                        : loadModuleFromNearestNodeModulesDirectory(Extensions.DtsOnly, typeReferenceDirectiveName, initialLocationForSecondaryLookup, moduleResolutionState, /*cache*/ undefined, /*redirectedReference*/ undefined);
+
                     result = searchResult && searchResult.value;
                 }
                 else {
@@ -1405,7 +1452,9 @@ namespace ts {
                     if (traceEnabled) {
                         trace(host, Diagnostics.Loading_module_0_from_node_modules_folder_target_file_type_1, moduleName, Extensions[extensions]);
                     }
-                    resolved = loadModuleFromNearestNodeModulesDirectory(extensions, moduleName, containingDirectory, state, cache, redirectedReference);
+                    resolved = getPnpApi(containingDirectory)
+                        ? tryLoadModuleUsingPnpResolution(extensions, moduleName, containingDirectory, state, cache, redirectedReference)
+                        : loadModuleFromNearestNodeModulesDirectory(extensions, moduleName, containingDirectory, state, cache, redirectedReference);
                 }
                 if (!resolved) return undefined;
 
@@ -2432,7 +2481,15 @@ namespace ts {
 
     function loadModuleFromSpecificNodeModulesDirectory(extensions: Extensions, moduleName: string, nodeModulesDirectory: string, nodeModulesDirectoryExists: boolean, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined): Resolved | undefined {
         const candidate = normalizePath(combinePaths(nodeModulesDirectory, moduleName));
+        return loadModuleFromSpecificNodeModulesDirectoryImpl(extensions, moduleName, nodeModulesDirectory, nodeModulesDirectoryExists, state, cache, redirectedReference, candidate, /* rest */ undefined, /* packageDirectory */ undefined);
+    }
 
+    function loadModuleFromPnpResolution(extensions: Extensions, packageDirectory: string, rest: string, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined): Resolved | undefined {
+        const candidate = normalizePath(combinePaths(packageDirectory, rest));
+        return loadModuleFromSpecificNodeModulesDirectoryImpl(extensions, /*moduleName*/ undefined, /*nodeModulesDirectory*/ undefined, /*nodeModulesDirectoryExists*/ true, state, cache, redirectedReference, candidate, rest, packageDirectory);
+    }
+
+    function loadModuleFromSpecificNodeModulesDirectoryImpl(extensions: Extensions, moduleName: string | undefined, nodeModulesDirectory: string | undefined, nodeModulesDirectoryExists: boolean, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined, candidate: string, rest: string | undefined, packageDirectory: string | undefined): Resolved | undefined {
         // First look for a nested package.json, as in `node_modules/foo/bar/package.json`.
         let packageInfo = getPackageJsonInfo(candidate, !nodeModulesDirectoryExists, state);
         // But only if we're not respecting export maps (if we are, we might redirect around this location)
@@ -2479,8 +2536,10 @@ namespace ts {
             return withPackageId(packageInfo, pathAndExtension);
         };
 
-        const { packageName, rest } = parsePackageName(moduleName);
-        const packageDirectory = combinePaths(nodeModulesDirectory, packageName);
+        let packageName: string;
+        if (rest === undefined) ({ packageName, rest } = parsePackageName(moduleName!));
+        if (packageDirectory === undefined) packageDirectory = combinePaths(nodeModulesDirectory!, packageName!);
+
         if (rest !== "") {
             // Previous `packageInfo` may have been from a nested package.json; ensure we have the one from the package root now.
             packageInfo = getPackageJsonInfo(packageDirectory, !nodeModulesDirectoryExists, state);
@@ -2707,6 +2766,66 @@ namespace ts {
     function traceIfEnabled(state: ModuleResolutionState, diagnostic: DiagnosticMessage, ...args: string[]) {
         if (state.traceEnabled) {
             trace(state.host, diagnostic, ...args);
+        }
+    }
+
+    /**
+     * We only allow PnP to be used as a resolution strategy if TypeScript
+     * itself is executed under a PnP runtime (and we only allow it to access
+     * the current PnP runtime, not any on the disk). This ensures that we
+     * don't execute potentially malicious code that didn't already have a
+     * chance to be executed (if we're running within the runtime, it means
+     * that the runtime has already been executed).
+     * @internal
+     */
+    function getPnpApi(path: string) {
+        const {findPnpApi} = require("module");
+        if (findPnpApi === undefined) {
+            return undefined;
+        }
+        return findPnpApi(`${path}/`);
+    }
+
+    function loadPnpPackageResolution(packageName: string, containingDirectory: string) {
+        try {
+            const resolution = getPnpApi(containingDirectory).resolveToUnqualified(packageName, `${containingDirectory}/`, { considerBuiltins: false });
+            return normalizeSlashes(resolution).replace(/\/$/, "");
+        }
+        catch {
+            // Nothing to do
+        }
+    }
+
+    function loadPnpTypePackageResolution(packageName: string, containingDirectory: string) {
+        return loadPnpPackageResolution(getTypesPackageName(packageName), containingDirectory);
+    }
+
+    /* @internal */
+    function tryLoadModuleUsingPnpResolution(extensions: Extensions, moduleName: string, containingDirectory: string, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined) {
+        const {packageName, rest} = parsePackageName(moduleName);
+
+        const packageResolution = loadPnpPackageResolution(packageName, containingDirectory);
+        const packageFullResolution = packageResolution
+            ? loadModuleFromPnpResolution(extensions, packageResolution, rest, state, cache, redirectedReference)
+            : undefined;
+
+        let resolved;
+        if (packageFullResolution) {
+            resolved = packageFullResolution;
+        }
+        else if (extensions === Extensions.TypeScript || extensions === Extensions.DtsOnly) {
+            const typePackageResolution = loadPnpTypePackageResolution(packageName, containingDirectory);
+            const typePackageFullResolution = typePackageResolution
+                ? loadModuleFromPnpResolution(Extensions.DtsOnly, typePackageResolution, rest, state, cache, redirectedReference)
+                : undefined;
+
+            if (typePackageFullResolution) {
+                resolved = typePackageFullResolution;
+            }
+        }
+
+        if (resolved) {
+            return toSearchResult(resolved);
         }
     }
 }

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -749,7 +749,34 @@ namespace ts.moduleSpecifiers {
         if (!host.fileExists || !host.readFile) {
             return undefined;
         }
-        const parts: NodeModulePathParts = getNodeModulePathParts(path)!;
+        let parts: NodeModulePathParts | PackagePathParts | undefined
+            = getNodeModulePathParts(path);
+
+        let packageName: string | undefined;
+        if (!parts && typeof process.versions.pnp !== "undefined") {
+            const {findPnpApi} = require("module");
+            const pnpApi = findPnpApi(path);
+            const locator = pnpApi?.findPackageLocator(path);
+            // eslint-disable-next-line no-null/no-null
+            if (locator !== null && locator !== undefined) {
+                const sourceLocator = pnpApi.findPackageLocator(`${sourceDirectory}/`);
+                // Don't use the package name when the imported file is inside
+                // the source directory (prefer a relative path instead)
+                if (locator === sourceLocator) {
+                    return undefined;
+                }
+                const information = pnpApi.getPackageInformation(locator);
+                packageName = locator.name;
+                parts = {
+                    topLevelNodeModulesIndex: undefined,
+                    topLevelPackageNameIndex: undefined,
+                    // The last character from packageLocation is the trailing "/", we want to point to it
+                    packageRootIndex: information.packageLocation.length - 1,
+                    fileNameIndex: path.lastIndexOf(`/`),
+                };
+            }
+        }
+
         if (!parts) {
             return undefined;
         }
@@ -793,19 +820,26 @@ namespace ts.moduleSpecifiers {
             return undefined;
         }
 
-        const globalTypingsCacheLocation = host.getGlobalTypingsCacheLocation && host.getGlobalTypingsCacheLocation();
-        // Get a path that's relative to node_modules or the importing file's path
-        // if node_modules folder is in this folder or any of its parent folders, no need to keep it.
-        const pathToTopLevelNodeModules = getCanonicalFileName(moduleSpecifier.substring(0, parts.topLevelNodeModulesIndex));
-        if (!(startsWith(sourceDirectory, pathToTopLevelNodeModules) || globalTypingsCacheLocation && startsWith(getCanonicalFileName(globalTypingsCacheLocation), pathToTopLevelNodeModules))) {
-            return undefined;
+        // If PnP is enabled the node_modules entries we'll get will always be relevant even if they
+        // are located in a weird path apparently outside of the source directory
+        if (typeof process.versions.pnp === "undefined") {
+            const globalTypingsCacheLocation = host.getGlobalTypingsCacheLocation && host.getGlobalTypingsCacheLocation();
+            // Get a path that's relative to node_modules or the importing file's path
+            // if node_modules folder is in this folder or any of its parent folders, no need to keep it.
+            const pathToTopLevelNodeModules = getCanonicalFileName(moduleSpecifier.substring(0, parts.topLevelNodeModulesIndex));
+            if (!(startsWith(sourceDirectory, pathToTopLevelNodeModules) || globalTypingsCacheLocation && startsWith(getCanonicalFileName(globalTypingsCacheLocation), pathToTopLevelNodeModules))) {
+                return undefined;
+            }
         }
 
         // If the module was found in @types, get the actual Node package name
-        const nodeModulesDirectoryName = moduleSpecifier.substring(parts.topLevelPackageNameIndex + 1);
-        const packageName = getPackageNameFromTypesPackageName(nodeModulesDirectoryName);
+        const nodeModulesDirectoryName = typeof packageName !== "undefined"
+            ? packageName + moduleSpecifier.substring(parts.packageRootIndex)
+            : moduleSpecifier.substring(parts.topLevelPackageNameIndex! + 1);
+
+        const packageNameFromPath = getPackageNameFromTypesPackageName(nodeModulesDirectoryName);
         // For classic resolution, only allow importing from node_modules/@types, not other node_modules
-        return getEmitModuleResolutionKind(options) === ModuleResolutionKind.Classic && packageName === nodeModulesDirectoryName ? undefined : packageName;
+        return getEmitModuleResolutionKind(options) === ModuleResolutionKind.Classic && packageNameFromPath === nodeModulesDirectoryName ? undefined : packageNameFromPath;
 
         function tryDirectoryWithPackageJson(packageRootIndex: number): { moduleFileToTry: string, packageRootPath?: string, blockedByExports?: true, verbatimFromExports?: true } {
             const packageRootPath = path.substring(0, packageRootIndex);
@@ -868,7 +902,7 @@ namespace ts.moduleSpecifiers {
             }
             else {
                 // No package.json exists; an index.js will still resolve as the package name
-                const fileName = getCanonicalFileName(moduleFileToTry.substring(parts.packageRootIndex + 1));
+                const fileName = getCanonicalFileName(moduleFileToTry.substring(parts!.packageRootIndex + 1));
                 if (fileName === "index.d.ts" || fileName === "index.js" || fileName === "index.ts" || fileName === "index.tsx") {
                     return { moduleFileToTry, packageRootPath };
                 }

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1683,6 +1683,11 @@ namespace ts {
             }
 
             function isFileSystemCaseSensitive(): boolean {
+                // The PnP runtime is always case-sensitive
+                // @ts-ignore
+                if (process.versions.pnp) {
+                    return true;
+                }
                 // win32\win64 are case insensitive platforms
                 if (platform === "win32" || platform === "win64") {
                     return false;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7691,6 +7691,14 @@ namespace ts {
         readonly packageRootIndex: number;
         readonly fileNameIndex: number;
     }
+
+    export interface PackagePathParts {
+        readonly topLevelNodeModulesIndex: undefined;
+        readonly topLevelPackageNameIndex: undefined;
+        readonly packageRootIndex: number;
+        readonly fileNameIndex: number;
+    }
+
     export function getNodeModulePathParts(fullPath: string): NodeModulePathParts | undefined {
         // If fullPath can't be valid module file within node_modules, returns undefined.
         // Example of expected pattern: /base/path/node_modules/[@scope/otherpackage/@otherscope/node_modules/]package/[subdirectory/]file.js

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -308,7 +308,9 @@ namespace ts {
         /** Update the file name list from the disk */
         Partial,
         /** Reload completely by re-reading contents of config file from disk and updating program */
-        Full
+        Full,
+        /** Reload the resolutions */
+        Resolutions,
     }
 
     export interface SharedExtendedConfigFileWatcher<T> extends FileWatcher {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -803,6 +803,8 @@ namespace ts.server {
 
 
         private performanceEventHandler?: PerformanceEventHandler;
+        /*@internal*/
+        private pnpWatcher?: FileWatcher;
 
         private pendingPluginEnablements?: ESMap<Project, Promise<BeginEnablePluginResult>[]>;
         private currentPluginEnablementPromise?: Promise<void>;
@@ -875,6 +877,8 @@ namespace ts.server {
                     watchDirectory: returnNoopFileWatcher,
                 } :
                 getWatchFactory(this.host, watchLogLevel, log, getDetailWatchInfo);
+
+            this.pnpWatcher = this.watchPnpFile();
         }
 
         toPath(fileName: string) {
@@ -3036,6 +3040,9 @@ namespace ts.server {
                 if (args.watchOptions) {
                     this.hostConfiguration.watchOptions = convertWatchOptions(args.watchOptions)?.watchOptions;
                     this.logger.info(`Host watch options changed to ${JSON.stringify(this.hostConfiguration.watchOptions)}, it will be take effect for next watches.`);
+
+                    this.pnpWatcher?.close();
+                    this.watchPnpFile();
                 }
             }
         }
@@ -4226,6 +4233,32 @@ namespace ts.server {
                             : undefined;
                 }
             });
+        }
+
+        /*@internal*/
+        private watchPnpFile() {
+            if (typeof process.versions.pnp === "undefined") {
+                return;
+            }
+            const {findPnpApi} = require("module");
+            // eslint-disable-next-line no-null/no-null
+            const pnpFileName = findPnpApi(__filename).resolveRequest("pnpapi", /*issuer*/ null);
+            return this.watchFactory.watchFile(
+                pnpFileName,
+                () => {
+                    this.forEachProject(project => {
+                        for (const info of project.getScriptInfos()) {
+                            project.resolutionCache.invalidateResolutionOfFile(info.path);
+                        }
+                        project.markAsDirty();
+                        updateProjectIfDirty(project);
+                    });
+                    this.delayEnsureProjectForOpenFiles();
+                },
+                PollingInterval.Low,
+                this.hostConfiguration.watchOptions,
+                WatchType.ConfigFile,
+            );
         }
 
         /*@internal*/

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -4240,9 +4240,11 @@ namespace ts.server {
             if (typeof process.versions.pnp === "undefined") {
                 return;
             }
-            const {findPnpApi} = require("module");
-            // eslint-disable-next-line no-null/no-null
-            const pnpFileName = findPnpApi(__filename).resolveRequest("pnpapi", /*issuer*/ null);
+            const pnpApi = require("module").findPnpApi(__filename);
+            if (!pnpApi) {
+                return;
+            }
+            const pnpFileName = pnpApi.resolveRequest("pnpapi", /*issuer*/ null);
             return this.watchFactory.watchFile(
                 pnpFileName,
                 () => {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2501,6 +2501,44 @@ namespace ts.server {
         }
 
         updateReferences(refs: readonly ProjectReference[] | undefined) {
+            // @ts-ignore
+            if (process.versions.pnp) {
+                // With Plug'n'Play, dependencies that list peer dependencies
+                // are "virtualized": they are resolved to a unique (virtual)
+                // path that the underlying filesystem layer then resolve back
+                // to the original location.
+                //
+                // When a workspace depends on another workspace with peer
+                // dependencies, this other workspace will thus be resolved to
+                // a unique path that won't match what the initial project has
+                // listed in its `references` field, and TS thus won't leverage
+                // the reference at all.
+                //
+                // To avoid that, we compute here the virtualized paths for the
+                // user-provided references in our references by directly querying
+                // the PnP API. This way users don't have to know the virtual paths,
+                // but we still support them just fine even through references.
+
+                const basePath = this.getCurrentDirectory();
+                const {findPnpApi} = require("module");
+
+                const getPnpPath = (path: string) => {
+                    try {
+                        const pnpApi = findPnpApi(`${path}/`);
+                        const targetLocator = pnpApi.findPackageLocator(`${path}/`);
+                        const {packageLocation} = pnpApi.getPackageInformation(targetLocator);
+                        const request = combinePaths(targetLocator.name, getRelativePathFromDirectory(packageLocation, path, /*ignoreCase*/ false));
+                        return pnpApi.resolveToUnqualified(request, `${basePath}/`);
+                    }
+ catch {
+                        // something went wrong with the resolution, try not to fail
+                        return path;
+                    }
+                };
+
+                refs = refs?.map(r => ({ ...r, path: getPnpPath(r.path) }));
+            }
+
             this.projectReferences = refs;
             this.potentialProjectReferences = undefined;
         }

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -325,13 +325,47 @@ namespace ts {
      * Don't include something from a `node_modules` that isn't actually reachable by a global import.
      * A relative import to node_modules is usually a bad idea.
      */
-    function isImportablePath(fromPath: string, toPath: string, getCanonicalFileName: GetCanonicalFileName, globalCachePath?: string): boolean {
+    function isImportablePathNode(fromPath: string, toPath: string, getCanonicalFileName: GetCanonicalFileName, globalCachePath?: string): boolean {
         // If it's in a `node_modules` but is not reachable from here via a global import, don't bother.
         const toNodeModules = forEachAncestorDirectory(toPath, ancestor => getBaseFileName(ancestor) === "node_modules" ? ancestor : undefined);
         const toNodeModulesParent = toNodeModules && getDirectoryPath(getCanonicalFileName(toNodeModules));
         return toNodeModulesParent === undefined
             || startsWith(getCanonicalFileName(fromPath), toNodeModulesParent)
             || (!!globalCachePath && startsWith(getCanonicalFileName(globalCachePath), toNodeModulesParent));
+    }
+
+    function getPnpApi(path: string) {
+        const {findPnpApi} = require("module");
+        if (findPnpApi === undefined) {
+            return undefined;
+        }
+        return findPnpApi(`${path}/`);
+    }
+
+    function isImportablePathPnp(fromPath: string, toPath: string): boolean {
+        const pnpApi = getPnpApi(fromPath);
+
+        const fromLocator = pnpApi.findPackageLocator(fromPath);
+        const toLocator = pnpApi.findPackageLocator(toPath);
+
+        // eslint-disable-next-line no-null/no-null
+        if (toLocator === null) {
+            return false;
+        }
+
+        const fromInfo = pnpApi.getPackageInformation(fromLocator);
+        const toReference = fromInfo.packageDependencies.get(toLocator.name);
+
+        return toReference === toLocator.reference;
+    }
+
+    function isImportablePath(fromPath: string, toPath: string, getCanonicalFileName: GetCanonicalFileName, globalCachePath?: string): boolean {
+        if (getPnpApi(fromPath)) {
+            return isImportablePathPnp(fromPath, toPath);
+        }
+        else {
+            return isImportablePathNode(fromPath, toPath, getCanonicalFileName, globalCachePath);
+        }
     }
 
     export function forEachExternalModuleToImportFrom(

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -1,7 +1,10 @@
 {
     "extends": "../tsconfig-base",
     "compilerOptions": {
-        "outFile": "../../built/local/services.js"
+        "outFile": "../../built/local/services.js",
+        "types": [
+            "node"
+        ]
     },
     "references": [
         { "path": "../compiler" },

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -209,6 +209,11 @@ namespace ts.server {
                     }
                     try {
                         const args = [combinePaths(__dirname, "watchGuard.js"), path];
+                        if (typeof process.versions.pnp !== "undefined") {
+                            const {findPnpApi} = require("module");
+                            // eslint-disable-next-line no-null/no-null
+                            args.unshift("-r", findPnpApi(__filename).resolveRequest("pnpapi", /* issuer */ null));
+                        }
                         if (logger.hasLevel(LogLevel.verbose)) {
                             logger.info(`Starting ${process.execPath} with args:${stringifyIndented(args)}`);
                         }
@@ -505,6 +510,12 @@ namespace ts.server {
                         execArgv.push(`--${match[1]}=${currentPort + 1}`);
                         break;
                     }
+                }
+
+                if (typeof process.versions.pnp !== "undefined") {
+                    const {findPnpApi} = require("module");
+                            // eslint-disable-next-line no-null/no-null
+                            execArgv.unshift("-r", findPnpApi(__filename).resolveRequest("pnpapi", /* issuer */ null));
                 }
 
                 this.installer = childProcess.fork(combinePaths(__dirname, "typingsInstaller.js"), args, { execArgv });

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -210,9 +210,10 @@ namespace ts.server {
                     try {
                         const args = [combinePaths(__dirname, "watchGuard.js"), path];
                         if (typeof process.versions.pnp !== "undefined") {
-                            const {findPnpApi} = require("module");
-                            // eslint-disable-next-line no-null/no-null
-                            args.unshift("-r", findPnpApi(__filename).resolveRequest("pnpapi", /* issuer */ null));
+                            const pnpApi = require("module").findPnpApi(__filename);
+                            if (pnpApi) {
+                                args.unshift('-r', pnpApi.resolveRequest("pnpapi", /* issuer */ null));
+                            }
                         }
                         if (logger.hasLevel(LogLevel.verbose)) {
                             logger.info(`Starting ${process.execPath} with args:${stringifyIndented(args)}`);
@@ -513,9 +514,10 @@ namespace ts.server {
                 }
 
                 if (typeof process.versions.pnp !== "undefined") {
-                    const {findPnpApi} = require("module");
-                            // eslint-disable-next-line no-null/no-null
-                            execArgv.unshift("-r", findPnpApi(__filename).resolveRequest("pnpapi", /* issuer */ null));
+                    const pnpApi = require("module").findPnpApi(__filename);
+                    if (pnpApi) {
+                        execArgv.unshift('-r', pnpApi.resolveRequest("pnpapi", /* issuer */ null));
+                    }
                 }
 
                 this.installer = childProcess.fork(combinePaths(__dirname, "typingsInstaller.js"), args, { execArgv });


### PR DESCRIPTION
I'm using a global installation of `typescript-language-server` that uses PnP, but working on a project that uses Yarn with `nodeLinker: node-modules` and a local TypeScript installation. In this case, `process.versions.pnp` is set, but `findPnpApi` will return null for project files.

I have a bunch of failing tests on macos all related to file watching. I assume that's unrelated to this, but will check.